### PR TITLE
fix: replace bare except clauses with except Exception in forge.py

### DIFF
--- a/src/forge.py
+++ b/src/forge.py
@@ -22,7 +22,7 @@ def get_open_issues():
              
         formatted = "\n".join([f"#{i['number']}: {i['title']}" for i in issues])
         return formatted
-    except:
+    except Exception:
         return "Could not fetch issues (gh cli error)."
 
 def get_branch_diff(base_branch="master"):
@@ -40,7 +40,7 @@ def get_branch_diff(base_branch="master"):
                  base_branch = "master"
              
         return run_shell(f"git diff {base_branch}...HEAD", check=False), base_branch
-    except:
+    except Exception:
         return None, "master"
 
 def handle_uncommitted_changes(mode="fast"):


### PR DESCRIPTION
Fixes #13

### Summary
Bare `except:` clauses catch all exceptions including `SystemExit` and `KeyboardInterrupt`, which should generally propagate. Changed to `except Exception:` to only catch standard errors.

### Changes
```
src/forge.py | 4 ++--
1 file changed, 2 insertions(+), 2 deletions(-)
```

---
<sub>If this fix isn't quite right, please leave feedback and I'll revise it.</sub>
