### PR TITLE
Fix bare except clause in optimize_topics (PEP 8 E722)

### DIFF
--- a/src/repo_tools.py
+++ b/src/repo_tools.py
@@ -61,7 +61,7 @@ Output Example: ["python", "automation"]
                 run_shell(f'gh repo edit {username}/{name} --add-topic "{tag_str}"')
                 count += 1
                 time.sleep(0.5)
-        except:
+        except json.JSONDecodeError:
             console.print(f"  [red]Failed to parse topics for {name}[/red]")
 
     console.print(f"[cyan]Done! Optimized {count} repositories.[/cyan]")


### PR DESCRIPTION
Addressing issue #12 

- Swapped `except:` for except `json.JSONDecodeError:` in the optimize_topics loop.

Opted for `json.JSONDecodeError` over `Exception` to ensure other unexpected logic errors aren't masked.