### PR TITLE
refactor: standardize JSON parsing of LLM responses

### DIFF
--- a/src/architect.py
+++ b/src/architect.py
@@ -7,7 +7,7 @@ from typing import Optional, Literal
 from rich.console import Console
 from rich.prompt import Confirm
 from .core import generate_content
-from .utils import run_shell
+from .utils import run_shell, parse_json_response
 
 console = Console()
 
@@ -40,8 +40,10 @@ Do NOT use markdown blocks.
         return
 
     try:
-        clean_result = result.replace("```json", "").replace("```", "").strip()
-        data = json.loads(clean_result)
+        data = parse_json_response(result)
+        if not data or not isinstance(data, dict):
+             raise ValueError("Failed to parse AI response as JSON")
+             
         commands = data.get("commands", [])
         
         console.print("[green]Generated Plan:[/green]")

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,0 +1,55 @@
+import sys
+import os
+
+# Ensure src is in path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from src.utils import parse_json_response
+
+def test_parse_clean_json():
+    text = '{"key": "value"}'
+    assert parse_json_response(text) == {"key": "value"}
+
+def test_parse_markdown_json():
+    text = 'Here is the json:\n```json\n{"key": "value"}\n```'
+    assert parse_json_response(text) == {"key": "value"}
+
+def test_parse_markdown_no_lang():
+    text = '```\n{"key": "value"}\n```'
+    assert parse_json_response(text) == {"key": "value"}
+
+def test_parse_with_surrounding_text():
+    text = 'Here is the response:\n```json\n{"key": "value"}\n```\nHope this helps!'
+    assert parse_json_response(text) == {"key": "value"}
+
+def test_parse_invalid_json():
+    text = 'Not a json'
+    assert parse_json_response(text) is None
+
+def test_parse_list():
+    text = '[1, 2, 3]'
+    assert parse_json_response(text) == [1, 2, 3]
+
+if __name__ == "__main__":
+    tests = [
+        test_parse_clean_json,
+        test_parse_markdown_json,
+        test_parse_markdown_no_lang,
+        test_parse_with_surrounding_text,
+        test_parse_invalid_json,
+        test_parse_list
+    ]
+    
+    success = 0
+    for test in tests:
+        try:
+            test()
+            print(f"PASSED: {test.__name__}")
+            success += 1
+        except AssertionError as e:
+            print(f"FAILED: {test.__name__}")
+            # print details
+    
+    print(f"\n{success}/{len(tests)} tests passed.")
+    if success != len(tests):
+        sys.exit(1)


### PR DESCRIPTION
This PR refactors the LLM response parsing logic to consistently use a dedicated  function. This improves robustness and maintainability by centralizing JSON handling and providing a fallback mechanism for non-JSON responses.

## Technical Changes

*   Introduced  in  to handle JSON parsing, stripping markdown code blocks, and providing error handling.
*   Updated  and  to utilize the new  function.
*   Added basic validation to ensure the parsed response is a dictionary.
*   Improved commit message cleanup in  to remove markdown and quotes, and truncate to a single line.
*   Enhanced PR data parsing in  to handle cases where the LLM provides plain text instead of JSON, attempting to extract title and body.
*   Fixed a potential issue in  where commit messages could contain multiple lines.

Fixes #29

> Forged by Git-Alchemist ⚗️