### PR TITLE
fix(cli): preserve Literal type for mode in command dispatch

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -12,6 +12,7 @@ from .committer import suggest_commits
 from .forge import forge_pr
 from .helper import run_helper
 
+Mode = Literal["fast", "smart"]
 console = Console()
 
 def main() -> None:
@@ -70,7 +71,11 @@ def main() -> None:
         parser.print_help()
         return
 
-    mode: Literal["fast", "smart"] = "smart" if args.smart else "fast"
+    mode: Mode
+    if args.smart:
+        mode = "smart"
+    else:
+        mode = "fast"
     
     if args.command == "profile":
         generate_profile(args.user, args.force, mode=mode)


### PR DESCRIPTION
## Summary

This PR fixes the `mypy` errors reported in `src/cli.py` by preserving the narrow literal type used for command dispatch mode.

## What changed

- Introduced a `Mode` type alias as `Literal["fast", "smart"]`
- Replaced the inline conditional assignment of `mode` with an explicit branch assignment
- Kept the CLI command dispatch unchanged while ensuring downstream functions receive the expected literal type

## Why

The previous implementation assigned `mode` using a conditional expression, which caused `mypy` to widen the inferred type more than expected in this context. Several command handlers require `Literal["fast", "smart"]`, so the type mismatch surfaced as multiple static type errors in `src/cli.py`.

Using an explicit branch preserves the intended literal typing cleanly and avoids adding unnecessary casts.

## Validation

```bash
mypy src/cli.py
mypy src